### PR TITLE
Add method to change input source

### DIFF
--- a/pylgnetcast/pylgnetcast.py
+++ b/pylgnetcast/pylgnetcast.py
@@ -31,6 +31,7 @@ LG_HANDLE_MOUSE_MOVE = "HandleTouchMove"
 LG_HANDLE_MOUSE_CLICK = "HandleTouchClick"
 LG_HANDLE_TOUCH_WHEEL = "HandleTouchWheel"
 LG_HANDLE_CHANNEL_CHANGE = "HandleChannelChange"
+LG_CHANGE_INPUT_SOURCE = "ChangeInputSource"
 
 DEFAULT_PORT = 8080
 DEFAULT_TIMEOUT = 3
@@ -154,6 +155,15 @@ class LgNetCastClient(object):
             self._session,
             LG_HANDLE_KEY_INPUT,
             "<value>%s</value>" % command,
+        )
+        self._send_to_tv("command", message)
+
+    def change_input_source(self, type, index):
+        """Send change input source command to the TV."""
+        message = self.COMMAND % (
+            self._session,
+            LG_CHANGE_INPUT_SOURCE,
+            "<inputSourceType>%d</inputSourceType><inputSourceIdx>%d</inputSourceIdx>" % (type, index),
         )
         self._send_to_tv("command", message)
 


### PR DESCRIPTION
I found this command [here](https://github.com/openlgtv/roap-pvr/blob/master/roap/roap_commands.js). The type and index of the currently selected input are present in the response to the `cur_channel` query, under the `inputSourceType` and `inputSourceIdx` keys. Unfortunately I haven't been able to find anything to list all configured sources, so it requires a bit of trial and error to find the necessary values. I've no idea what versions are required for this to work; I only tested it on my 2014 model.

I've uploaded a forked version of the Home Assistant integration with input switching implemented [here](https://github.com/oxan/home-assistant-lg_netcast/). Feel free to steal from there to merge into the official integration, if you want. As it adds a YAML configuration option and HA has gone nuclear on those, I won't work on upstreaming it myself.