### PR TITLE
Fix LG TVs pre 2012 (can't get session id)

### DIFF
--- a/pylgnetcast/pylgnetcast.py
+++ b/pylgnetcast/pylgnetcast.py
@@ -261,7 +261,7 @@ class LgNetCastClient(object):
 
     def _send_to_tv(self, message_type, message=None, payload=None):
         """Send message of given type to the tv."""
-        if message_type != "command" and self.protocol == LG_PROTOCOL.HDCP:
+        if message_type == "command" and self.protocol == LG_PROTOCOL.HDCP:
             message_type = "dtv_wifirc"
         url = "%s%s" % (self.url, message_type)
         if message:


### PR DESCRIPTION
Fix for LG TVs pre 2012.
Without it cant get the session id